### PR TITLE
Fix file paths in windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,11 +28,11 @@ module.exports = function (options) {
 
 		// have to create a new connection for each file otherwise they conflict
 		var ftp = new JSFtp(options);
-		var relativePath = file.path.replace(file.cwd + '/', '');
-		var finalRemotePath = path.join('/', remotePath, relativePath);
-		
+		var relativePath = file.path.replace(file.cwd + path.sep, '');
+		var finalRemotePath = path.join('/', remotePath, relativePath).replace(/\\/g,'/');
+
 		var self = this;
-		ftp.mkdirp(path.dirname(finalRemotePath), function (err) {
+		ftp.mkdirp(path.dirname(finalRemotePath).replace(/\\/g,'/'), function (err) {
 			if (err) {
 				self.emit('error', new gutil.PluginError('gulp-ftp', err));
 				return cb();


### PR DESCRIPTION
Fixes #7

nodejs path uses the OS's path seperator, but ftp requires forward-slashes.

Also requires sindresorhus/jsftp-mkdirp#1
