### PR TITLE
No deletion of options.remotePath

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ module.exports = function (options) {
 
 	var fileCount = 0;
 	var remotePath = options.remotePath || '';
-	delete options.remotePath;
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -29,7 +28,12 @@ module.exports = function (options) {
 		var self = this;
 
 		// have to create a new connection for each file otherwise they conflict
-		var ftp = new JSFtp(options);
+		var ftp = new JSFtp({
+			host: options.host,
+			port: options.port,
+			user: options.user,
+			pass: options.pass
+		});
 
 		var finalRemotePath = path.join('/', remotePath, file.relative).replace(/\\/g, '/');
 


### PR DESCRIPTION
Hello Sindre,

The 'remotePath' option is currently deleted when gulp-ftp runs for the first time : https://github.com/sindresorhus/gulp-ftp/blob/master/index.js#L16 .

If 'options' is a reference to a previously defined object, this deletes the original definition of 'remotePath' and prevents this object from being used again, like with 'watch'.

Example: https://github.com/vkammerer/mekaviz.com/blob/master/gulpfile.js

Not deleting the property, and passing the options to JSFtp as in this PR solves the problem.
